### PR TITLE
Cross-conversion between types

### DIFF
--- a/Sources/RectangleTools/Basic Protocols/DualTwoDimensional.swift
+++ b/Sources/RectangleTools/Basic Protocols/DualTwoDimensional.swift
@@ -26,6 +26,15 @@ public protocol DualTwoDimensional {
     
     /// The second key `TwoDimensional` in this object
     var secondDimensionPair: SecondDimensionPair { get }
+    
+    
+    
+    /// Creates a new dual 2D object by combining the two given 2D objects
+    ///
+    /// - Parameters:
+    ///   - firstDimensionPair:  The first of the dual 2D objects
+    ///   - secondDimensionPair: The second of the dual 2D objects
+    init(firstDimensionPair: FirstDimensionPair, secondDimensionPair: SecondDimensionPair)
 }
 
 
@@ -67,6 +76,11 @@ public extension DualTwoDimensional
 public extension DualTwoDimensional where Self: Rectangle {
     var firstDimensionPair: Point { origin }
     var secondDimensionPair: Size { size }
+    
+    
+    init(firstDimensionPair: Point, secondDimensionPair: Size) {
+        self.init(origin: firstDimensionPair, size: secondDimensionPair)
+    }
 }
 
 

--- a/Sources/RectangleTools/Basic Protocols/Point2D.swift
+++ b/Sources/RectangleTools/Basic Protocols/Point2D.swift
@@ -55,6 +55,11 @@ public extension Point2D {
     var measurementY: Length {
         get { y }
     }
+    
+    
+    init(measurementX: Length, measurementY: Length) {
+        self.init(x: measurementX, y: measurementY)
+    }
 }
 
 

--- a/Sources/RectangleTools/Basic Protocols/Size2D.swift
+++ b/Sources/RectangleTools/Basic Protocols/Size2D.swift
@@ -55,6 +55,11 @@ public extension Size2D {
     var measurementY: Length {
         get { height }
     }
+    
+    
+    init(measurementX: Length, measurementY: Length) {
+        self.init(width: measurementX, height: measurementY)
+    }
 }
 
 

--- a/Sources/RectangleTools/Basic Protocols/TwoDimensional.swift
+++ b/Sources/RectangleTools/Basic Protocols/TwoDimensional.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 
-/// Something which can be measured using two dimensions
+/// Something which can be measured using only two dimensions
 public protocol TwoDimensional {
     
     associatedtype Length
@@ -22,6 +22,14 @@ public protocol TwoDimensional {
     
     /// The measurement in the second dimension (along the Y axis)
     var measurementY: Length { get }
+    
+    
+    /// Creates a new 2D object with the given X and Y measurements
+    ///
+    /// - Parameters:
+    ///   - measurementX: The measurement in the first dimension
+    ///   - measurementY: The measurement in the second dimension
+    init(measurementX: Length, measurementY: Length)
 }
 
 

--- a/Sources/RectangleTools/Synthesized Conveniences/DualTwoDimensional Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/DualTwoDimensional Extensions.swift
@@ -1,0 +1,139 @@
+//
+//  DualTwoDimensional Extensions.swift
+//  RectangleTools
+//
+//  Created by Ben Leggiero on 2019-12-09.
+//  Copyright © 2019 Ben Leggiero BH-1-PS.
+//
+
+import Foundation
+
+
+
+public extension DualTwoDimensional
+    where
+        FirstDimensionPair.Length: BinaryInteger,
+        SecondDimensionPair.Length: BinaryInteger
+{
+    
+    /// Creates a new dual 2D object by converting the values of the given one
+    ///
+    /// - Parameter other: Another dual 2D object to convert
+    init<Other>(_ other: Other)
+        where Other: DualTwoDimensional,
+            Other.FirstDimensionPair.Length: BinaryInteger,
+            Other.SecondDimensionPair.Length: BinaryInteger
+    {
+        self.init(firstDimensionPair: .init(other.firstDimensionPair),
+                  secondDimensionPair: .init(other.secondDimensionPair))
+    }
+    
+    
+    /// Attempts to create a new dual 2D object by converting the values of the given one. If that can't be done (e.g.
+    /// the other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another dual 2D object to convert
+    /// - Returns: `nil` iff the other dual 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: DualTwoDimensional,
+            Other.FirstDimensionPair.Length: BinaryInteger,
+            Other.SecondDimensionPair.Length: BinaryInteger
+    {
+        guard
+            let otherFirst = FirstDimensionPair.init(exactly: other.firstDimensionPair),
+            let otherSecond = SecondDimensionPair.init(exactly: other.secondDimensionPair)
+            else
+        {
+            return nil
+        }
+        
+        self.init(firstDimensionPair: otherFirst, secondDimensionPair: otherSecond)
+    }
+    
+    
+    /// Attempts to create a new dual 2D object by converting the values of the given one. If that can't be done (e.g.
+    /// the other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another dual 2D object to convert
+    /// - Returns: `nil` iff the other dual 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: DualTwoDimensional,
+            Other.FirstDimensionPair.Length: BinaryFloatingPoint,
+            Other.SecondDimensionPair.Length: BinaryFloatingPoint
+    {
+        guard
+            let otherFirst = FirstDimensionPair.init(exactly: other.firstDimensionPair),
+            let otherSecond = SecondDimensionPair.init(exactly: other.secondDimensionPair)
+            else
+        {
+            return nil
+        }
+        
+        self.init(firstDimensionPair: otherFirst, secondDimensionPair: otherSecond)
+    }
+}
+
+
+
+public extension DualTwoDimensional
+    where
+        FirstDimensionPair.Length: BinaryFloatingPoint,
+        SecondDimensionPair.Length: BinaryFloatingPoint
+{
+    
+    /// Creates a new dual 2D object by converting the values of the given one
+    ///
+    /// - Parameter other: Another dual 2D object to convert
+    init<Other>(_ other: Other)
+        where Other: DualTwoDimensional,
+            Other.FirstDimensionPair.Length: BinaryFloatingPoint,
+            Other.SecondDimensionPair.Length: BinaryFloatingPoint
+    {
+        self.init(firstDimensionPair: .init(other.firstDimensionPair),
+                  secondDimensionPair: .init(other.secondDimensionPair))
+    }
+    
+    
+    /// Attempts to create a new dual 2D object by converting the values of the given one. If that can't be done (e.g.
+    /// the other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another dual 2D object to convert
+    /// - Returns: `nil` iff the other dual 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: DualTwoDimensional,
+            Other.FirstDimensionPair.Length: BinaryInteger,
+            Other.SecondDimensionPair.Length: BinaryInteger
+    {
+        guard
+            let otherFirst = FirstDimensionPair.init(exactly: other.firstDimensionPair),
+            let otherSecond = SecondDimensionPair.init(exactly: other.secondDimensionPair)
+            else
+        {
+            return nil
+        }
+        
+        self.init(firstDimensionPair: otherFirst, secondDimensionPair: otherSecond)
+    }
+    
+    
+    /// Attempts to create a new dual 2D object by converting the values of the given one. If that can't be done (e.g.
+    /// the other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another dual 2D object to convert
+    /// - Returns: `nil` iff the other dual 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: DualTwoDimensional,
+            Other.FirstDimensionPair.Length: BinaryFloatingPoint,
+            Other.SecondDimensionPair.Length: BinaryFloatingPoint
+    {
+        guard
+            let otherFirst = FirstDimensionPair.init(exactly: other.firstDimensionPair),
+            let otherSecond = SecondDimensionPair.init(exactly: other.secondDimensionPair)
+            else
+        {
+            return nil
+        }
+        
+        self.init(firstDimensionPair: otherFirst, secondDimensionPair: otherSecond)
+    }
+}

--- a/Sources/RectangleTools/Synthesized Conveniences/Point2D Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/Point2D Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  Point2D Extensions.swift
+//  RectangleTools
+//
+//  Created by Ben Leggiero on 2019-12-08.
+//  Copyright © 2019 Ben Leggiero BH-1-PS.
+//
+
+import Foundation
+
+
+
+public extension Point2D {
+    
+    /// Creates a copy of the given point
+    ///
+    /// - Parameter other: Another point to copy
+    init(_ other: Self) {
+        self.init(x: other.x, y: other.y)
+    }
+}

--- a/Sources/RectangleTools/Synthesized Conveniences/Size2D Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/Size2D Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  Size2D Extensions.swift
+//  RectangleTools
+//
+//  Created by Ben Leggiero on 2019-12-08.
+//  Copyright © 2019 Ben Leggiero BH-1-PS.
+//
+
+import Foundation
+
+
+
+public extension Size2D {
+    
+    /// Creates a copy of the given size
+    ///
+    /// - Parameter other: Another size to copy
+    init(_ other: Self) {
+        self.init(width: other.width, height: other.height)
+    }
+}

--- a/Sources/RectangleTools/Synthesized Conveniences/TwoDimensional Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/TwoDimensional Extensions.swift
@@ -1,0 +1,123 @@
+//
+//  TwoDimensional Extensions.swift
+//  RectangleTools
+//
+//  Created by Ben Leggiero on 2019-12-08.
+//  Copyright © 2019 Ben Leggiero BH-1-PS.
+//
+
+import Foundation
+
+
+
+public extension TwoDimensional where Length: BinaryFloatingPoint {
+    
+    /// Creates a new 2D object by converting the values of the given one
+    ///
+    /// - Parameter other: Another 2D object to convert
+    init<Other>(_ other: Other)
+        where Other: TwoDimensional,
+            Other.Length: BinaryFloatingPoint
+    {
+        self.init(measurementX: Length.init(other.measurementX), measurementY: Length.init(other.measurementY))
+    }
+    
+    
+    /// Attempts to create a new 2D object by converting the values of the given one. If that can't be done (e.g. the
+    /// other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another 2D object to convert
+    /// - Returns: `nil` iff the other 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: TwoDimensional,
+            Other.Length: BinaryInteger
+    {
+        guard
+            let otherX = Length.init(exactly: other.measurementX),
+            let otherY = Length.init(exactly: other.measurementY)
+            else
+        {
+            return nil
+        }
+        
+        self.init(measurementX: otherX, measurementY: otherY)
+    }
+    
+    
+    /// Attempts to create a new 2D object by converting the values of the given one. If that can't be done (e.g. the
+    /// other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another 2D object to convert
+    /// - Returns: `nil` iff the other 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: TwoDimensional,
+            Other.Length: BinaryFloatingPoint
+    {
+        guard
+            let otherX = Length.init(exactly: other.measurementX),
+            let otherY = Length.init(exactly: other.measurementY)
+            else
+        {
+            return nil
+        }
+        
+        self.init(measurementX: otherX, measurementY: otherY)
+    }
+}
+
+
+
+public extension TwoDimensional where Length: BinaryInteger {
+    
+    /// Creates a new 2D object by converting the values of the given one
+    ///
+    /// - Parameter other: Another 2D object to convert
+    init<Other>(_ other: Other)
+        where Other: TwoDimensional,
+            Other.Length: BinaryInteger
+    {
+        self.init(measurementX: .init(other.measurementX), measurementY: .init(other.measurementY))
+    }
+    
+    
+    /// Attempts to create a new 2D object by converting the values of the given one. If that can't be done (e.g. the
+    /// other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another 2D object to convert
+    /// - Returns: `nil` iff the other 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: TwoDimensional,
+            Other.Length: BinaryInteger
+    {
+        guard
+            let otherX = Length.init(exactly: other.measurementX),
+            let otherY = Length.init(exactly: other.measurementY)
+            else
+        {
+            return nil
+        }
+        
+        self.init(measurementX: otherX, measurementY: otherY)
+    }
+    
+    
+    /// Attempts to create a new 2D object by converting the values of the given one. If that can't be done (e.g. the
+    /// other's bit width is larger than this one), `nil` is returned.
+    ///
+    /// - Parameter other: Another 2D object to convert
+    /// - Returns: `nil` iff the other 2D object couldn't be exactly converted to the target type
+    init?<Other>(exactly other: Other)
+        where Other: TwoDimensional,
+            Other.Length: BinaryFloatingPoint
+    {
+        guard
+            let otherX = Length.init(exactly: other.measurementX),
+            let otherY = Length.init(exactly: other.measurementY)
+            else
+        {
+            return nil
+        }
+        
+        self.init(measurementX: otherX, measurementY: otherY)
+    }
+}


### PR DESCRIPTION
In order to implement this, new non-optional requirements had to be placed on `TwoDimensional` and `DualTwoDimensional` to make their implementers initializable from their perspective.

Although it is not very likely that this package is in such wide usage that this will actually be a problem in existing codebases, nonetheless it is a breaking change which will require new code to be written to support it. Thus, this ushers in version `2.0.0`! 🥳