### PR TITLE
Set Swift GitHub Action timeout to 5 minutes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
 
+    timeout-minutes: 5
     runs-on: macOS-latest
 
     steps:


### PR DESCRIPTION
This will help speed up turnaround for infinitely-looping tests. I expect tests to take 15-45 seconds at most, and GitHub defaults to letting them run for 6 hours.