### PR TITLE
Added some functions to find points in rectangles by percentage

### DIFF
--- a/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
+++ b/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
@@ -1,0 +1,35 @@
+//
+//  InitializableFromInteger.swift
+//  
+//
+//  Created by Ben Leggiero on 2019-12-28.
+//
+
+import Foundation
+
+
+
+public protocol InitializableFromInteger {
+    init<BI>(_ integer: BI) where BI: BinaryInteger
+}
+
+
+
+// MARK: -
+
+extension Int: InitializableFromInteger {}
+extension Int8: InitializableFromInteger {}
+extension Int16: InitializableFromInteger {}
+extension Int32: InitializableFromInteger {}
+extension Int64: InitializableFromInteger {}
+
+extension UInt: InitializableFromInteger {}
+extension UInt8: InitializableFromInteger {}
+extension UInt16: InitializableFromInteger {}
+extension UInt32: InitializableFromInteger {}
+extension UInt64: InitializableFromInteger {}
+
+extension Float32: InitializableFromInteger {}
+extension Float64: InitializableFromInteger {}
+extension Float80: InitializableFromInteger {}
+extension CGFloat: InitializableFromInteger {}

--- a/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
+++ b/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
@@ -9,7 +9,10 @@ import Foundation
 
 
 
+/// Anything which can be losslessly initialized from an integer
 public protocol InitializableFromInteger {
+    
+    /// Creates a new instance based on the given integer
     init<BI>(_ integer: BI) where BI: BinaryInteger
 }
 

--- a/Sources/RectangleTools/Synthesized Conveniences/Rectangle Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/Rectangle Extensions.swift
@@ -148,7 +148,7 @@ public extension Rectangle
 
 public extension Rectangle where Self.Length: ExpressibleByIntegerLiteral {
     
-    /// Returns this rectangle placed with its origin at (0, 0)
+    /// Returns a copy of this rectangle, with its origin placed at (0, 0)
     var withOriginZero: Self {
         Self.init(origin: .zero, size: size)
     }
@@ -165,7 +165,7 @@ public extension Rectangle
     /// Finds the X coordinate which is the given percent along the X axis of this rectangle
     ///
     /// - Parameter xPercent: The percent along the X axis where the point's X coordinate should be
-    func percentAlongX(_ xPercent: Length) -> Length {
+    func percent(alongX xPercent: Length) -> Length {
         return self.minX + (self.width * xPercent)
     }
     
@@ -173,7 +173,7 @@ public extension Rectangle
     /// Finds the Y coordinate which is the given percent along the Y axis of this rectangle
     ///
     ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
-    func percentAlongY(_ yPercent: Length) -> Length {
+    func percent(alongY yPercent: Length) -> Length {
         return self.minY + (self.height * yPercent)
     }
     
@@ -184,8 +184,8 @@ public extension Rectangle
     ///   - xPercent: The percent along the X axis where the point's X coordinate should be
     ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
     func relativePoint(xPercent: Length, yPercent: Length) -> Point {
-        Point.init(x: percentAlongX(xPercent),
-                   y: percentAlongY(yPercent))
+        Point.init(x: percent(alongX: xPercent),
+                   y: percent(alongY: yPercent))
     }
     
     
@@ -194,7 +194,7 @@ public extension Rectangle
     /// - Parameter yPercent: The percent along the Y axis of the `maxX` edge where the point's Y coordinate should be
     func maxX(yPercent: Length) -> Point {
         Point.init(x: self.maxX,
-                   y: percentAlongY(yPercent))
+                   y: percent(alongY: yPercent))
     }
 
 
@@ -203,7 +203,7 @@ public extension Rectangle
     /// - Parameter yPercent: The percent along the Y axis of the `minX` edge where the point's Y coordinate should be
     func minX(yPercent: Length) -> Point {
         Point.init(x: self.minX,
-                   y: percentAlongY(yPercent))
+                   y: percent(alongY: yPercent))
     }
 
 
@@ -211,7 +211,7 @@ public extension Rectangle
     ///
     /// - Parameter xPercent: The percent along the X axis of the `maxY` edge where the point's X coordinate should be
     func maxY(xPercent: Length) -> Point {
-        Point.init(x: percentAlongX(xPercent),
+        Point.init(x: percent(alongX: xPercent),
                    y: self.maxY)
     }
 
@@ -220,7 +220,7 @@ public extension Rectangle
     ///
     /// - Parameter xPercent: The percent along the X axis of the `minY` edge where the point's X coordinate should be
     func minY(xPercent: Length) -> Point {
-        Point.init(x: percentAlongX(xPercent),
+        Point.init(x: percent(alongX: xPercent),
                    y: self.minY)
     }
 }
@@ -234,7 +234,7 @@ public extension Rectangle
     /// Finds the X coordinate which is the given percent along the X axis of this rectangle
     ///
     /// - Parameter xPercent: The percent along the X axis where the point's X coordinate should be
-    func percentAlongX<Percent>(_ xPercent: Percent) -> Length
+    func percent<Percent>(alongX xPercent: Percent) -> Length
         where Percent: BinaryFloatingPoint
     {
         return Length.init(Percent.init(self.minX) + (Percent.init(self.width) * xPercent))
@@ -244,7 +244,7 @@ public extension Rectangle
     /// Finds the Y coordinate which is the given percent along the Y axis of this rectangle
     ///
     ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
-    func percentAlongY<Percent>(_ yPercent: Percent) -> Length
+    func percent<Percent>(alongY yPercent: Percent) -> Length
         where Percent: BinaryFloatingPoint
     {
         return Length.init(Percent.init(self.minY) + (Percent.init(self.height) * yPercent))
@@ -259,8 +259,8 @@ public extension Rectangle
     func relativePoint<Percent>(xPercent: Percent, yPercent: Percent) -> Point
         where Percent: BinaryFloatingPoint
     {
-        Point.init(x: percentAlongX(xPercent),
-                   y: percentAlongY(yPercent))
+        Point.init(x: percent(alongX: xPercent),
+                   y: percent(alongY: yPercent))
     }
     
     
@@ -271,7 +271,7 @@ public extension Rectangle
         where Percent: BinaryFloatingPoint
     {
         Point.init(x: self.maxX,
-                   y: percentAlongY(yPercent))
+                   y: percent(alongY: yPercent))
     }
 
 
@@ -282,7 +282,7 @@ public extension Rectangle
         where Percent: BinaryFloatingPoint
     {
         Point.init(x: self.minX,
-                   y: percentAlongY(yPercent))
+                   y: percent(alongY: yPercent))
     }
 
 
@@ -292,7 +292,7 @@ public extension Rectangle
     func maxY<Percent>(xPercent: Percent) -> Point
         where Percent: BinaryFloatingPoint
     {
-        Point.init(x: percentAlongX(xPercent),
+        Point.init(x: percent(alongX: xPercent),
                    y: self.maxY)
     }
 
@@ -303,7 +303,7 @@ public extension Rectangle
     func minY<Percent>(xPercent: Percent) -> Point
         where Percent: BinaryFloatingPoint
     {
-        Point.init(x: percentAlongX(xPercent),
+        Point.init(x: percent(alongX: xPercent),
                    y: self.minY)
     }
 }

--- a/Sources/RectangleTools/Synthesized Conveniences/Rectangle Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/Rectangle Extensions.swift
@@ -12,6 +12,7 @@ import MultiplicativeArithmetic
 
 
 public extension Rectangle  {
+    
     /// Conveniently returns the rectangle's size's width
     @inlinable
     var width: Length { size.width }
@@ -44,9 +45,14 @@ public extension Rectangle  {
 
 
 
-public extension Rectangle where Length: Comparable, Length: AdditiveArithmetic {
-    
-    // MARK: Lines
+// MARK: - Extremes
+
+public extension Rectangle
+    where
+        Length: Comparable,
+        Length: AdditiveArithmetic
+{
+    // MARK: Edges
     
     /// The smallest X value in this rectangle
     @inlinable
@@ -88,13 +94,16 @@ public extension Rectangle where Length: Comparable, Length: AdditiveArithmetic 
 
 
 
+// MARK: - Mids
+
 public extension Rectangle
-    where Length: Comparable,
+    where
+        Length: Comparable,
         Length: AdditiveArithmetic,
         Length: MultiplicativeArithmetic,
         Length: ExpressibleByIntegerLiteral
 {
-    // MARK: Line
+    // MARK: Edges
     
     /// The middlemost X value in this rectangle
     @inlinable
@@ -131,4 +140,170 @@ public extension Rectangle
     /// The middle of the high vertical edge on this rectangle
     @inlinable
     var maxXmidY: Point { Point.init(x: maxX, y: midY) }
+}
+
+
+
+// MARK: -
+
+public extension Rectangle where Self.Length: ExpressibleByIntegerLiteral {
+    
+    /// Returns this rectangle placed with its origin at (0, 0)
+    var withOriginZero: Self {
+        Self.init(origin: .zero, size: size)
+    }
+}
+
+
+
+// MARK: - Relative/percent points
+
+public extension Rectangle
+    where
+        Length: BinaryFloatingPoint
+{
+    /// Finds the X coordinate which is the given percent along the X axis of this rectangle
+    ///
+    /// - Parameter xPercent: The percent along the X axis where the point's X coordinate should be
+    func percentAlongX(_ xPercent: Length) -> Length {
+        return self.minX + (self.width * xPercent)
+    }
+    
+    
+    /// Finds the Y coordinate which is the given percent along the Y axis of this rectangle
+    ///
+    ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
+    func percentAlongY(_ yPercent: Length) -> Length {
+        return self.minY + (self.height * yPercent)
+    }
+    
+    
+    /// Returns a point in this rectangle with the given relative percent coordinates
+    ///
+    /// - Parameters:
+    ///   - xPercent: The percent along the X axis where the point's X coordinate should be
+    ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
+    func relativePoint(xPercent: Length, yPercent: Length) -> Point {
+        Point.init(x: percentAlongX(xPercent),
+                   y: percentAlongY(yPercent))
+    }
+    
+    
+    /// Returns a point at the given percent along the `maxX` edge of this rectangle
+    ///
+    /// - Parameter yPercent: The percent along the Y axis of the `maxX` edge where the point's Y coordinate should be
+    func maxX(yPercent: Length) -> Point {
+        Point.init(x: self.maxX,
+                   y: percentAlongY(yPercent))
+    }
+
+
+    /// Returns a point at the given percent along the `minX` edge of this rectangle
+    ///
+    /// - Parameter yPercent: The percent along the Y axis of the `minX` edge where the point's Y coordinate should be
+    func minX(yPercent: Length) -> Point {
+        Point.init(x: self.minX,
+                   y: percentAlongY(yPercent))
+    }
+
+
+    /// Returns a point at the given percent along the `maxY` edge of this rectangle
+    ///
+    /// - Parameter xPercent: The percent along the X axis of the `maxY` edge where the point's X coordinate should be
+    func maxY(xPercent: Length) -> Point {
+        Point.init(x: percentAlongX(xPercent),
+                   y: self.maxY)
+    }
+
+
+    /// Returns a point at the given percent along the `minY` edge of this rectangle
+    ///
+    /// - Parameter xPercent: The percent along the X axis of the `minY` edge where the point's X coordinate should be
+    func minY(xPercent: Length) -> Point {
+        Point.init(x: percentAlongX(xPercent),
+                   y: self.minY)
+    }
+}
+
+
+
+public extension Rectangle
+    where
+        Length: BinaryInteger
+{
+    /// Finds the X coordinate which is the given percent along the X axis of this rectangle
+    ///
+    /// - Parameter xPercent: The percent along the X axis where the point's X coordinate should be
+    func percentAlongX<Percent>(_ xPercent: Percent) -> Length
+        where Percent: BinaryFloatingPoint
+    {
+        return Length.init(Percent.init(self.minX) + (Percent.init(self.width) * xPercent))
+    }
+    
+    
+    /// Finds the Y coordinate which is the given percent along the Y axis of this rectangle
+    ///
+    ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
+    func percentAlongY<Percent>(_ yPercent: Percent) -> Length
+        where Percent: BinaryFloatingPoint
+    {
+        return Length.init(Percent.init(self.minY) + (Percent.init(self.height) * yPercent))
+    }
+    
+    
+    /// Returns a point in this rectangle with the given relative percent coordinates
+    ///
+    /// - Parameters:
+    ///   - xPercent: The percent along the X axis where the point's X coordinate should be
+    ///   - yPercent: The percent along the Y axis where the point's Y coordinate should be
+    func relativePoint<Percent>(xPercent: Percent, yPercent: Percent) -> Point
+        where Percent: BinaryFloatingPoint
+    {
+        Point.init(x: percentAlongX(xPercent),
+                   y: percentAlongY(yPercent))
+    }
+    
+    
+    /// Returns a point at the given percent along the `maxX` edge of this rectangle
+    ///
+    /// - Parameter yPercent: The percent along the Y axis of the `maxX` edge where the point's Y coordinate should be
+    func maxX<Percent>(yPercent: Percent) -> Point
+        where Percent: BinaryFloatingPoint
+    {
+        Point.init(x: self.maxX,
+                   y: percentAlongY(yPercent))
+    }
+
+
+    /// Returns a point at the given percent along the `minX` edge of this rectangle
+    ///
+    /// - Parameter yPercent: The percent along the Y axis of the `minX` edge where the point's Y coordinate should be
+    func minX<Percent>(yPercent: Percent) -> Point
+        where Percent: BinaryFloatingPoint
+    {
+        Point.init(x: self.minX,
+                   y: percentAlongY(yPercent))
+    }
+
+
+    /// Returns a point at the given percent along the `maxY` edge of this rectangle
+    ///
+    /// - Parameter xPercent: The percent along the X axis of the `maxY` edge where the point's X coordinate should be
+    func maxY<Percent>(xPercent: Percent) -> Point
+        where Percent: BinaryFloatingPoint
+    {
+        Point.init(x: percentAlongX(xPercent),
+                   y: self.maxY)
+    }
+
+
+    /// Returns a point at the given percent along the `minY` edge of this rectangle
+    ///
+    /// - Parameter xPercent: The percent along the X axis of the `minY` edge where the point's X coordinate should be
+    func minY<Percent>(xPercent: Percent) -> Point
+        where Percent: BinaryFloatingPoint
+    {
+        Point.init(x: percentAlongX(xPercent),
+                   y: self.minY)
+    }
 }

--- a/Sources/RectangleTools/Synthesized Conveniences/Size2D Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/Size2D Extensions.swift
@@ -23,9 +23,12 @@ public extension Size2D {
 
 
 
-public extension Size2D where Length: Comparable, Length: AdditiveArithmetic {
-    
-    // MARK: Lines
+public extension Size2D
+    where
+        Length: Comparable,
+        Length: AdditiveArithmetic
+{
+    // MARK: Edges
     
     /// The smallest X value in this size
     @inlinable
@@ -68,12 +71,13 @@ public extension Size2D where Length: Comparable, Length: AdditiveArithmetic {
 
 
 public extension Size2D
-    where Length: Comparable,
+    where
+        Length: Comparable,
         Length: AdditiveArithmetic,
         Length: MultiplicativeArithmetic,
         Length: ExpressibleByIntegerLiteral
 {
-    // MARK: Line
+    // MARK: Edges
     
     /// The middlemost X value in this size
     @inlinable

--- a/Tests/RectangleToolsTests/Rectangle Position Tests.swift
+++ b/Tests/RectangleToolsTests/Rectangle Position Tests.swift
@@ -248,11 +248,11 @@ extension RectanglePositionTests {
         XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.75), UIntPoint(x: 7 + 12, y: 11 + 9))
         XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 1   ), UIntPoint(x: 7 + 12, y: 11 + 12))
         
-        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 1Self.uIntRect_12x12at7x11.y))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: Self.uIntRect_12x12at7x11.minY))
         XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.25), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11 + 3))
         XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.5 ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11 + 6))
         XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.75), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11 + 9))
-        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11Self.uIntRect_12x12at7x11.y))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: Self.uIntRect_12x12at7x11.maxY))
         
         
         XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0   ), CGPoint(x: 7 + 12, y: 11 + 0))
@@ -261,11 +261,11 @@ extension RectanglePositionTests {
         XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.75), CGPoint(x: 7 + 12, y: 11 + 9))
         XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 1   ), CGPoint(x: 7 + 12, y: 11 + 12))
         
-        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 1Self.cgRect_12x12at7x11.y))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: Self.cgRect_12x12at7x11.minY))
         XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.25), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11 + 3))
         XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.5 ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11 + 6))
         XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.75), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11 + 9))
-        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 1   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11Self.cgRect_12x12at7x11.y))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 1   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: Self.cgRect_12x12at7x11.maxY))
         
         
         
@@ -275,11 +275,11 @@ extension RectanglePositionTests {
         XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.75), UIntPoint(x: 5 + 13, y: 8 + 15))
         XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 1   ), UIntPoint(x: 5 + 13, y: 8 + 21))
         
-        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: Self.uIntRect_13x21at5x8.y))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: Self.uIntRect_13x21at5x8.minY))
         XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.25), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8 + 5))
         XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.5 ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8 + 10))
         XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.75), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8 + 15))
-        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8Self.uIntRect_13x21at5x8.y))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: Self.uIntRect_13x21at5x8.maxY))
         
         
         XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0   ), CGPoint(x: 5 + 13, y: 8 + 0))
@@ -288,17 +288,185 @@ extension RectanglePositionTests {
         XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.75), CGPoint(x: 5 + 13, y: 8 + 15.75))
         XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 1   ), CGPoint(x: 5 + 13, y: 8 + 21))
         
-        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: Self.cgRect_13x21at5x8.y))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: Self.cgRect_13x21at5x8.minY))
         XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.25), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8 + 5.25))
         XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.5 ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8 + 10.5))
         XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.75), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8 + 15.75))
-        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 1   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8Self.cgRect_13x21at5x8.y))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 1   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: Self.cgRect_13x21at5x8.maxY))
+    }
+    
+    
+    func testMinX_yPercent() {
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0   ), UIntPoint(x: 7 + 0, y: 11 + 0))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0.25), UIntPoint(x: 7 + 0, y: 11 + 3))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0.5 ), UIntPoint(x: 7 + 0, y: 11 + 6))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0.75), UIntPoint(x: 7 + 0, y: 11 + 9))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 1   ), UIntPoint(x: 7 + 0, y: 11 + 12))
+        
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: Self.uIntRect_12x12at7x11.minY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0.25), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: 11 + 3))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0.5 ), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: 11 + 6))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 0.75), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: 11 + 9))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.minX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: Self.uIntRect_12x12at7x11.maxY))
+        
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0   ), CGPoint(x: 7 + 0, y: 11 + 0))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0.25), CGPoint(x: 7 + 0, y: 11 + 3))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0.5 ), CGPoint(x: 7 + 0, y: 11 + 6))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0.75), CGPoint(x: 7 + 0, y: 11 + 9))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 1   ), CGPoint(x: 7 + 0, y: 11 + 12))
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0   ), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: Self.cgRect_12x12at7x11.minY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0.25), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: 11 + 3))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0.5 ), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: 11 + 6))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 0.75), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: 11 + 9))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.minX(yPercent: 1   ), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: Self.cgRect_12x12at7x11.maxY))
+        
+        
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0   ), UIntPoint(x: 5 + 0, y: 8 + 0))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0.25), UIntPoint(x: 5 + 0, y: 8 + 5))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0.5 ), UIntPoint(x: 5 + 0, y: 8 + 10))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0.75), UIntPoint(x: 5 + 0, y: 8 + 15))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 1   ), UIntPoint(x: 5 + 0, y: 8 + 21))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: Self.uIntRect_13x21at5x8.minY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0.25), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: 8 + 5))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0.5 ), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: 8 + 10))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 0.75), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: 8 + 15))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.minX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: Self.uIntRect_13x21at5x8.maxY))
+        
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0   ), CGPoint(x: 5 + 0, y: 8 + 0))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0.25), CGPoint(x: 5 + 0, y: 8 + 5.25))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0.5 ), CGPoint(x: 5 + 0, y: 8 + 10.5))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0.75), CGPoint(x: 5 + 0, y: 8 + 15.75))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 1   ), CGPoint(x: 5 + 0, y: 8 + 21))
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0   ), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: Self.cgRect_13x21at5x8.minY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0.25), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: 8 + 5.25))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0.5 ), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: 8 + 10.5))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 0.75), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: 8 + 15.75))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.minX(yPercent: 1   ), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: Self.cgRect_13x21at5x8.maxY))
+    }
+    
+    
+    func testMinY_xPercent() {
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0   ), UIntPoint(x: 7 + 0, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.25), UIntPoint(x: 7 + 3, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.5 ), UIntPoint(x: 7 + 6, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.75), UIntPoint(x: 7 + 9, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 1   ), UIntPoint(x: 7 + 12, y: 11 + 12))
+        
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0   ), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.25), UIntPoint(x: 7 + 3, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.5 ), UIntPoint(x: 7 + 6, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.75), UIntPoint(x: 7 + 9, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 1   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: Self.uIntRect_12x12at7x11.maxY))
+        
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0   ), CGPoint(x: 7 + 0, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.25), CGPoint(x: 7 + 3, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.5 ), CGPoint(x: 7 + 6, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.75), CGPoint(x: 7 + 9, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 1   ), CGPoint(x: 7 + 12, y: 11 + 12))
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0   ), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.25), CGPoint(x: 7 + 3, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.5 ), CGPoint(x: 7 + 6, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.75), CGPoint(x: 7 + 9, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 1   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: Self.cgRect_12x12at7x11.maxY))
+        
+        
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0   ), UIntPoint(x: 5 + 0, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.25), UIntPoint(x: 5 + 3, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.5 ), UIntPoint(x: 5 + 6, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.75), UIntPoint(x: 5 + 9, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 1   ), UIntPoint(x: 5 + 13, y: 8 + 21))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0   ), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.25), UIntPoint(x: 5 + 3, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.5 ), UIntPoint(x: 5 + 6, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.75), UIntPoint(x: 5 + 9, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 1   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: Self.uIntRect_13x21at5x8.maxY))
+        
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0   ), CGPoint(x: 5 + 0, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.25), CGPoint(x: 5 + 3.25, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.5 ), CGPoint(x: 5 + 6.5, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.75), CGPoint(x: 5 + 9.75, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 1   ), CGPoint(x: 5 + 13, y: 8 + 21))
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0   ), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.25), CGPoint(x: 5 + 3.25, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.5 ), CGPoint(x: 5 + 6.5, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.75), CGPoint(x: 5 + 9.75, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 1   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: Self.cgRect_13x21at5x8.maxY))
+    }
+    
+    
+    func testMaxY_xPercent() {
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0   ), UIntPoint(x: 7 + 0, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.25), UIntPoint(x: 7 + 3, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.5 ), UIntPoint(x: 7 + 6, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.75), UIntPoint(x: 7 + 9, y: 11 + 12))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 1   ), UIntPoint(x: 7 + 12, y: 11 + 12))
+        
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0   ), UIntPoint(x: Self.uIntRect_12x12at7x11.minX, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.25), UIntPoint(x: 7 + 3, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.5 ), UIntPoint(x: 7 + 6, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 0.75), UIntPoint(x: 7 + 9, y: Self.uIntRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxY(xPercent: 1   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: Self.uIntRect_12x12at7x11.maxY))
+        
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0   ), CGPoint(x: 7 + 0, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.25), CGPoint(x: 7 + 3, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.5 ), CGPoint(x: 7 + 6, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.75), CGPoint(x: 7 + 9, y: 11 + 12))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 1   ), CGPoint(x: 7 + 12, y: 11 + 12))
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0   ), CGPoint(x: Self.cgRect_12x12at7x11.minX, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.25), CGPoint(x: 7 + 3, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.5 ), CGPoint(x: 7 + 6, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 0.75), CGPoint(x: 7 + 9, y: Self.cgRect_12x12at7x11.maxY))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxY(xPercent: 1   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: Self.cgRect_12x12at7x11.maxY))
+        
+        
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0   ), UIntPoint(x: 5 + 0, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.25), UIntPoint(x: 5 + 3, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.5 ), UIntPoint(x: 5 + 6, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.75), UIntPoint(x: 5 + 9, y: 8 + 21))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 1   ), UIntPoint(x: 5 + 13, y: 8 + 21))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0   ), UIntPoint(x: Self.uIntRect_13x21at5x8.minX, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.25), UIntPoint(x: 5 + 3, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.5 ), UIntPoint(x: 5 + 6, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 0.75), UIntPoint(x: 5 + 9, y: Self.uIntRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxY(xPercent: 1   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: Self.uIntRect_13x21at5x8.maxY))
+        
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0   ), CGPoint(x: 5 + 0, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.25), CGPoint(x: 5 + 3.25, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.5 ), CGPoint(x: 5 + 6.5, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.75), CGPoint(x: 5 + 9.75, y: 8 + 21))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 1   ), CGPoint(x: 5 + 13, y: 8 + 21))
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0   ), CGPoint(x: Self.cgRect_13x21at5x8.minX, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.25), CGPoint(x: 5 + 3.25, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.5 ), CGPoint(x: 5 + 6.5, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 0.75), CGPoint(x: 5 + 9.75, y: Self.cgRect_13x21at5x8.maxY))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxY(xPercent: 1   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: Self.cgRect_13x21at5x8.maxY))
     }
     
     
     static let relativePercentTests = [
         ("testRelativePoint", testRelativePoint),
         ("testMaxX_yPercent", testMaxX_yPercent),
+        ("testMinX_yPercent", testMinX_yPercent),
+        ("testMaxY_xPercent", testMaxY_xPercent),
+        ("testMinY_xPercent", testMinY_xPercent),
     ]
 }
 

--- a/Tests/RectangleToolsTests/Rectangle Position Tests.swift
+++ b/Tests/RectangleToolsTests/Rectangle Position Tests.swift
@@ -57,11 +57,13 @@ final class RectanglePositionTests: XCTestCase {
     static let allTests =
           lineTests
         + pointTests
+        + relativePercentTests
+        + otherTests
 }
 
 
 
-// MARK: - Lines
+// MARK: - Edges
 
 extension RectanglePositionTests {
     
@@ -205,5 +207,118 @@ extension RectanglePositionTests {
         ("testMaxXminY", testMaxXminY),
         ("testMaxXmidY", testMaxXmidY),
         ("testMaxXmaxY", testMaxXmaxY),
+    ]
+}
+
+
+
+// MARK: - Relative/percent points
+
+extension RectanglePositionTests {
+    
+    static let uIntRect_12x12at7x11 = UIntRect(x: 7, y: 11, width: 12, height: 12)
+    static let cgRect_12x12at7x11 = CGRect(x: 7, y: 11, width: 12, height: 12)
+    static let uIntRect_13x21at5x8 = UIntRect(x: 5, y: 8, width: 13, height: 21)
+    static let cgRect_13x21at5x8 = CGRect(x: 5, y: 8, width: 13, height: 21)
+    
+    
+    func testRelativePoint() {
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.relativePoint(xPercent: 0.5, yPercent: 0.5), UIntPoint(x: 7 + 6, y: 11 + 6))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.relativePoint(xPercent: 0.5, yPercent: 0.5), CGPoint(x: 7 + 6, y: 11 + 6))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.relativePoint(xPercent: 0.5, yPercent: 0.5), UIntPoint(x: 5 + 6, y: 8 + 10))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.relativePoint(xPercent: 0.5, yPercent: 0.5), CGPoint(x: 5 + 6.5, y: 8 + 10.5))
+        
+        
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.relativePoint(xPercent: 0.25, yPercent: 0.75), UIntPoint(x: 7 + 3, y: 11 + 9))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.relativePoint(xPercent: 0.25, yPercent: 0.75), CGPoint(x: 7 + 3, y: 11 + 9))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.relativePoint(xPercent: 0.25, yPercent: 0.25), UIntPoint(x: 5 + 3, y: 8 + 5))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.relativePoint(xPercent: 0.25, yPercent: 0.25), CGPoint(x: 5 + 3.25, y: 8 + 5.25))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.relativePoint(xPercent: 0.75, yPercent: 0.75), UIntPoint(x: 5 + 9, y: 8 + 15))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.relativePoint(xPercent: 0.75, yPercent: 0.75), CGPoint(x: 5 + 9.75, y: 8 + 15.75))
+    }
+    
+    
+    func testMaxX_yPercent() {
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0   ), UIntPoint(x: 7 + 12, y: 11 + 0))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.25), UIntPoint(x: 7 + 12, y: 11 + 3))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.5 ), UIntPoint(x: 7 + 12, y: 11 + 6))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.75), UIntPoint(x: 7 + 12, y: 11 + 9))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 1   ), UIntPoint(x: 7 + 12, y: 11 + 12))
+        
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 1Self.uIntRect_12x12at7x11.y))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.25), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11 + 3))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.5 ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11 + 6))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 0.75), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11 + 9))
+        XCTAssertEqual(Self.uIntRect_12x12at7x11.maxX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_12x12at7x11.maxX, y: 11Self.uIntRect_12x12at7x11.y))
+        
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0   ), CGPoint(x: 7 + 12, y: 11 + 0))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.25), CGPoint(x: 7 + 12, y: 11 + 3))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.5 ), CGPoint(x: 7 + 12, y: 11 + 6))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.75), CGPoint(x: 7 + 12, y: 11 + 9))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 1   ), CGPoint(x: 7 + 12, y: 11 + 12))
+        
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 1Self.cgRect_12x12at7x11.y))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.25), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11 + 3))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.5 ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11 + 6))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 0.75), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11 + 9))
+        XCTAssertEqual(Self.cgRect_12x12at7x11.maxX(yPercent: 1   ), CGPoint(x: Self.cgRect_12x12at7x11.maxX, y: 11Self.cgRect_12x12at7x11.y))
+        
+        
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0   ), UIntPoint(x: 5 + 13, y: 8 + 0))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.25), UIntPoint(x: 5 + 13, y: 8 + 5))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.5 ), UIntPoint(x: 5 + 13, y: 8 + 10))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.75), UIntPoint(x: 5 + 13, y: 8 + 15))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 1   ), UIntPoint(x: 5 + 13, y: 8 + 21))
+        
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: Self.uIntRect_13x21at5x8.y))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.25), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8 + 5))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.5 ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8 + 10))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 0.75), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8 + 15))
+        XCTAssertEqual(Self.uIntRect_13x21at5x8.maxX(yPercent: 1   ), UIntPoint(x: Self.uIntRect_13x21at5x8.maxX, y: 8Self.uIntRect_13x21at5x8.y))
+        
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0   ), CGPoint(x: 5 + 13, y: 8 + 0))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.25), CGPoint(x: 5 + 13, y: 8 + 5.25))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.5 ), CGPoint(x: 5 + 13, y: 8 + 10.5))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.75), CGPoint(x: 5 + 13, y: 8 + 15.75))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 1   ), CGPoint(x: 5 + 13, y: 8 + 21))
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: Self.cgRect_13x21at5x8.y))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.25), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8 + 5.25))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.5 ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8 + 10.5))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 0.75), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8 + 15.75))
+        XCTAssertEqual(Self.cgRect_13x21at5x8.maxX(yPercent: 1   ), CGPoint(x: Self.cgRect_13x21at5x8.maxX, y: 8Self.cgRect_13x21at5x8.y))
+    }
+    
+    
+    static let relativePercentTests = [
+        ("testRelativePoint", testRelativePoint),
+        ("testMaxX_yPercent", testMaxX_yPercent),
+    ]
+}
+
+
+
+// MARK: -
+
+extension RectanglePositionTests {
+    
+    func testWithOriginZero() {
+        XCTAssertEqual(Self.cgRect_13x21at5x8.withOriginZero, CGRect(x: 0, y: 0, width: 13, height: 21))
+        XCTAssertEqual(UIntRect(x: 5, y: 8, width: 13, height: 21).withOriginZero, UIntRect(x: 0, y: 0, width: 13, height: 21))
+        
+        XCTAssertEqual(Self.cgRect_13x21at5x8.withOriginZero, CGRect(origin: .zero, size: CGSize(width: 13, height: 21)))
+        
+        XCTAssertEqual(CGRect(x: 0, y: 0, width: 13, height: 21).withOriginZero, CGRect(x: 0, y: 0, width: 13, height: 21))
+    }
+    
+    
+    static let otherTests = [
+        ("testWithOriginZero", testWithOriginZero),
     ]
 }

--- a/Tests/RectangleToolsTests/Size Position Tests.swift
+++ b/Tests/RectangleToolsTests/Size Position Tests.swift
@@ -69,7 +69,7 @@ final class SizePositionTests: XCTestCase {
 
 
 
-// MARK: - Lines
+// MARK: - Edges
 
 extension SizePositionTests {
     


### PR DESCRIPTION
This introduces two separate sets of APIs, which I hope will work harmoniously.

1. Fetching a point within an **integer** rectangle by passing **some other floating-point type** percentages, which returns the rectangle's **integer** type
2. Fetching a point within a **floating-point** rectangle by passing **the rectangle's floating-point type** percentages, which returns the rectangle's **floating-point** type