### PR TITLE
Added support for iOS

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,3 +14,8 @@ jobs:
       run: swift build -v
     - name: Run tests
       run: swift test -v
+    - name: Generate iOS xcodeproj
+      run: swift package generate-xcodeproj
+    - name: Run iOS tests
+      run: xcodebuild build test -destination 'name=iPhone 11' -scheme 'RectangleTools-Package'
+

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git",
         "state": {
           "branch": null,
-          "revision": "71e7201b4debe94fe7dca6f10d6b34c487f991b2",
-          "version": "1.2.0"
+          "revision": "38eee08151bbbefbbb422d02ff2c8da1a8b8bfe1",
+          "version": "1.3.0"
         }
       }
     ]

--- a/Sources/RectangleTools/Basic Protocols/DualTwoDimensional.swift
+++ b/Sources/RectangleTools/Basic Protocols/DualTwoDimensional.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 
 

--- a/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
+++ b/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 
 
@@ -34,5 +35,7 @@ extension UInt64: InitializableFromInteger {}
 
 extension Float32: InitializableFromInteger {}
 extension Float64: InitializableFromInteger {}
+#if (arch(i386) || arch(x86_64)) && !os(Windows)
 extension Float80: InitializableFromInteger {}
+#endif
 extension CGFloat: InitializableFromInteger {}

--- a/Sources/RectangleTools/Default Conformances/CGPoint + Point2D.swift
+++ b/Sources/RectangleTools/Default Conformances/CGPoint + Point2D.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 
 

--- a/Sources/RectangleTools/Default Conformances/CGRect + Rectangle.swift
+++ b/Sources/RectangleTools/Default Conformances/CGRect + Rectangle.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 
 

--- a/Sources/RectangleTools/Default Conformances/CGSize + Size2D.swift
+++ b/Sources/RectangleTools/Default Conformances/CGSize + Size2D.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 
 

--- a/Sources/RectangleTools/Synthesized Conveniences/TwoDimensional Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/TwoDimensional Extensions.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 import MultiplicativeArithmetic
 
 

--- a/Tests/RectangleToolsTests/Test Constants.swift
+++ b/Tests/RectangleToolsTests/Test Constants.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 import RectangleTools
 
 


### PR DESCRIPTION
This mostly involved just importing CoreGraphics wherever `CGFloat` and its kin were needed, plus conditionally-compiling `Float80`. Also updated `MultiplicativeArithmetic` to 1.3.0.

This resolves #43
