### PR TITLE
3.0.0: Attempt to resolve compiler error with SwiftUI previews & generic targets by removing compiler conditionals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,18 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "RectangleTools",
+    
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
+    
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -13,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(url: "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git", from: "1.0.0"),
+        .package(name: "MultiplicativeArithmetic", url: "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/RectangleTools/Default Conformances/EdgeInsets + FourSided.swift
+++ b/Sources/RectangleTools/Default Conformances/EdgeInsets + FourSided.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Ben Leggiero. All rights reserved.
 //
 
+import SwiftUI
+
 #if canImport(WatchKit)
     import WatchKit
 
@@ -85,11 +87,6 @@ extension NSEdgeInsets: Equatable {}
 
 
 
-#if canImport(SwiftUI) && !RECTANGLETOOLS_EXCLUDE_SWIFTUI_EDGEINSETS
-import SwiftUI
-
-
-
 @available(macOS 10.15, *)
 @available(iOS 13, *)
 @available(tvOS 13, *)
@@ -142,11 +139,6 @@ public extension EdgeInsets {
         }
     }
 }
-#else
-
-public typealias EdgeInsets = NativeEdgeInsets
-
-#endif
 
 
 


### PR DESCRIPTION
Still unsure what causes #56, so now I'm removing the compiler conditions around SwiftUI and requiring newer platforms. 

