### PR TITLE
Introducing square initializers for `Size2D`

### DIFF
--- a/Sources/RectangleTools/Synthesized Conveniences/Size2D Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/Size2D Extensions.swift
@@ -19,6 +19,24 @@ public extension Size2D {
     init(_ other: Self) {
         self.init(width: other.width, height: other.height)
     }
+    
+    
+    /// Initializes a size where both dimensions are the same length
+    ///
+    /// - Parameter length: The width, and the height, of the new size
+    @inline(__always)
+    init(square length: Length) {
+        self.init(width: length, height: length)
+    }
+    
+    
+    /// A size where both dimensions are the same length
+    ///
+    /// - Parameter length: The width, and the height, of the returned size
+    @inline(__always)
+    static func square(_ length: Length) -> Self {
+        .init(square: length)
+    }
 }
 
 

--- a/Tests/RectangleToolsTests/Size initializatoin tests.swift
+++ b/Tests/RectangleToolsTests/Size initializatoin tests.swift
@@ -1,0 +1,40 @@
+//
+//  Test.swift
+//  RectangleTools
+//
+//  Created by Ky on 2026-02-03.
+//
+
+import CoreGraphics
+import Testing
+
+import RectangleTools
+
+
+
+struct Size_initialization_tests {
+    
+    @Test
+    func init_square() async throws {
+        squareTest(sizeGenerator: CGSize.init(square:))
+    }
+    
+    
+    @Test
+    func static_square() async throws {
+        squareTest(sizeGenerator: CGSize.square(_:))
+    }
+}
+
+
+
+private func squareTest(sourceLocation: SourceLocation = #_sourceLocation, sizeGenerator: (_ sideLength: CGFloat) -> CGSize) {
+    for i in 1...1000 {
+        let range = CGFloat(i) * .random(in: 0...10)
+        let sideLength = CGFloat.random(in: -range...range)
+        let size = sizeGenerator(sideLength)
+        #expect(size.width == sideLength, "A square with side length \(sideLength) should have width \(sideLength)", sourceLocation: sourceLocation)
+        #expect(size.height == sideLength, "A square with side length \(sideLength) should have height \(sideLength)", sourceLocation: sourceLocation)
+        #expect(size.minMeasurement == size.maxMeasurement, "All sides of a square should be equal", sourceLocation: sourceLocation)
+    }
+}


### PR DESCRIPTION
This introduces a convenience initializer and a static factory that create a square `Size2D` (where width and height are equal, given the single length value to use for each)