### PR TITLE
Linux support!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+
+.vscode/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "905826789c96f44101a947765c14433357abd543f3b6e4f83bbab415de5eebff",
+  "originHash" : "aa4f4a21f2d1b260d527a765d83098d44a66f1b8a7ce86d3728fd6339ee2e658",
   "pins" : [
     {
       "identity" : "swift-multiplicativearithmetic",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git",
       "state" : {
-        "revision" : "c45199953ac680dfdcaefff5f8743f1126fe8a4e",
-        "version" : "2.0.1"
+        "revision" : "960ccc54d6c876983c6658d4aca637b4685e9841",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git", from: "2.0.1"),
+        .package(url: "https://github.com/RougeWare/Swift-MultiplicativeArithmetic.git", from: "2.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Swift Rectangle Tools #
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FRougeWare%2FSwift-Rectangle-Tools%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/RougeWare/Swift-Rectangle-Tools)
+![Linux](https://img.shields.io/badge/Linux-supported-blue?logo=linux&logoColor=white)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FRougeWare%2FSwift-Rectangle-Tools%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/RougeWare/Swift-Rectangle-Tools)
+[![Swift Package Manager](https://img.shields.io/badge/SwiftPM-compatible-orange?logo=swift&logoColor=white)](https://swift.org/package-manager/)
+[![Fair License](https://img.shields.io/badge/License-Fair-green)](LICENSE.txt)
+![](https://img.shields.io/github/release-date/RougeWare/Swift-RectangleTools?display_date=published_at&label=Last%20updated)
+
 A set of Swift utilities for dealing with rectangles, including a way to generically build your own!
 
 This package includes:

--- a/Sources/RectangleTools/Basic Protocols/DualTwoDimensional.swift
+++ b/Sources/RectangleTools/Basic Protocols/DualTwoDimensional.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 
 

--- a/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
+++ b/Sources/RectangleTools/Basic Protocols/InitializableFromInteger.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 
 

--- a/Sources/RectangleTools/Default Conformances/CGPoint + Point2D.swift
+++ b/Sources/RectangleTools/Default Conformances/CGPoint + Point2D.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 
 

--- a/Sources/RectangleTools/Default Conformances/CGRect + Rectangle.swift
+++ b/Sources/RectangleTools/Default Conformances/CGRect + Rectangle.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 
 

--- a/Sources/RectangleTools/Default Conformances/CGSize + Size2D.swift
+++ b/Sources/RectangleTools/Default Conformances/CGSize + Size2D.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 
 

--- a/Sources/RectangleTools/Default Conformances/EdgeInsets + FourSided.swift
+++ b/Sources/RectangleTools/Default Conformances/EdgeInsets + FourSided.swift
@@ -28,6 +28,38 @@
 
     public typealias NativeEdgeInsets = NSEdgeInsets
     public typealias UserInterfaceLayoutDirection = NSUserInterfaceLayoutDirection
+#else
+    import Foundation
+    
+    public typealias NativeEdgeInsets = EdgeInsets
+    
+    
+    
+    /// Represents the amount by which something is inset from the edge of something else
+    /// 
+    /// This includes presumptive automatic localization by using leading/trailing sides instead of left/right.
+    public struct EdgeInsets<Length> {
+        public var top: Length
+        public var leading: Length
+        public var bottom: Length
+        public var trailing: Length
+        
+        
+        public init(top: Length, leading: Length, bottom: Length, trailing: Length) {
+            self.top = top
+            self.leading = leading
+            self.bottom = bottom
+            self.trailing = trailing
+        }
+    }
+    
+    
+    
+    /// The layout direction of the user interface, corresponding to the reading direction of the current language.
+    public enum UserInterfaceLayoutDirection {
+        case leftToRight
+        case rightToLeft
+    }
 #endif
 
 
@@ -35,9 +67,9 @@
 @available(watchOS 2.1, *)
 extension NativeEdgeInsets: FourSidedAbsolute {
     
-    #if canImport(SwiftUI)
+    #if canImport(SwiftUI) || !(canImport(WatchKit) || canImport(UIKit) || canImport(AppKit))
     
-    public init(top: CGFloat, right: CGFloat, bottom: CGFloat, left: CGFloat) {
+    public init(top: Length, right: Length, bottom: Length, left: Length) {
         switch UserInterfaceLayoutDirection.current {
         case .leftToRight:
             self.init(top: top, leading: left, bottom: bottom, trailing: right)
@@ -52,12 +84,12 @@ extension NativeEdgeInsets: FourSidedAbsolute {
     }
     
     
-    public init(top: CGFloat, trailing: CGFloat, bottom: CGFloat, leading: CGFloat) {
+    public init(top: Length, trailing: Length, bottom: Length, leading: Length) {
         self.init(top: top, leading: leading, bottom: bottom, trailing: trailing)
     }
     
     
-    public var left: CGFloat {
+    public var left: Length {
         switch UserInterfaceLayoutDirection.current {
         case .leftToRight: return leading
         case .rightToLeft: return trailing
@@ -69,7 +101,7 @@ extension NativeEdgeInsets: FourSidedAbsolute {
     }
     
     
-    public var right: CGFloat {
+    public var right: Length {
         switch UserInterfaceLayoutDirection.current {
         case .leftToRight: return trailing
         case .rightToLeft: return leading
@@ -81,16 +113,16 @@ extension NativeEdgeInsets: FourSidedAbsolute {
     }
     
     
-    #else
+    #elseif canImport(WatchKit) || canImport(UIKit) || canImport(AppKit)
     
     
     @available(watchOS 2.1, *)
-    public init(top: CGFloat, right: CGFloat, bottom: CGFloat, left: CGFloat) {
+    public init(top: Length, right: Length, bottom: Length, left: Length) {
         self.init(top: top, left: left, bottom: bottom, right: right)
     }
     
     
-    public init(top: CGFloat, trailing: CGFloat, bottom: CGFloat, leading: CGFloat) {
+    public init(top: Length, trailing: Length, bottom: Length, leading: Length) {
         switch UserInterfaceLayoutDirection.current {
         case .leftToRight:
             self.init(top: top, right: trailing, bottom: bottom, left: leading)
@@ -109,11 +141,11 @@ extension NativeEdgeInsets: FourSidedAbsolute {
 
 
 
-#if !canImport(SwiftUI)
+#if !canImport(SwiftUI) && (canImport(WatchKit) || canImport(UIKit) || canImport(AppKit))
 @available(watchOS 2.1, *)
 public extension NativeEdgeInsets {
     /// The value of whichever edge inset is leading in the current app's UI direction
-    var leading: CGFloat {
+    var leading: Length {
         switch UserInterfaceLayoutDirection.current {
         case .leftToRight: return left
         case .rightToLeft: return right
@@ -125,7 +157,7 @@ public extension NativeEdgeInsets {
     
     
     /// The value of whichever edge inset is trailing in the current app's UI direction
-    var trailing: CGFloat {
+    var trailing: Length {
         switch UserInterfaceLayoutDirection.current {
         case .leftToRight: return right
         case .rightToLeft: return left
@@ -163,6 +195,9 @@ public extension UserInterfaceLayoutDirection {
             let legacyCurrent = UIApplication.shared.userInterfaceLayoutDirection
         #elseif canImport(AppKit)
             let legacyCurrent = NSApp?.userInterfaceLayoutDirection ?? .leftToRight
+        #else
+            // TODO: Figure this out for common other platforms
+            let legacyCurrent = UserInterfaceLayoutDirection.leftToRight
         #endif
         
         #if canImport(SwiftUI)

--- a/Sources/RectangleTools/Synthesized Conveniences/TwoDimensional Extensions.swift
+++ b/Sources/RectangleTools/Synthesized Conveniences/TwoDimensional Extensions.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 import MultiplicativeArithmetic
 
 

--- a/Tests/RectangleToolsTests/Point Tests.swift
+++ b/Tests/RectangleToolsTests/Point Tests.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 #if canImport(CoreImage)
 import CoreImage
 #endif

--- a/Tests/RectangleToolsTests/Size initializatoin tests.swift
+++ b/Tests/RectangleToolsTests/Size initializatoin tests.swift
@@ -5,7 +5,9 @@
 //  Created by Ky on 2026-02-03.
 //
 
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 import Testing
 
 import RectangleTools

--- a/Tests/RectangleToolsTests/Test Constants.swift
+++ b/Tests/RectangleToolsTests/Test Constants.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 import RectangleTools
 

--- a/Tests/RectangleToolsTests/TwoDimensional operator tests.swift
+++ b/Tests/RectangleToolsTests/TwoDimensional operator tests.swift
@@ -6,7 +6,9 @@
 //
 
 import Testing
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 
 import RectangleTools
 


### PR DESCRIPTION
- Upgraded MultiplicativeArithmetic from 2.0.1 to 2.1.0, which introduces Linux support
- Only importing CoreGraphics when it's available
- Custom EdgeInsets implementation when outside Apple platforms
- Ignore `.vscode/`

This leaves one TODO: Add support for finding current RTL/LTR setting on Linux, Windows, BSD, etc.